### PR TITLE
Create new task definition based on current task definition

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,8 +1,8 @@
-memo = "c152d332114f6c773bf013454be5ca197015d70ffb6a454d629fa5a6de61ecf9"
+memo = "a7fe1541e2181f4a7d0d25c275e8c161d58dabda1be8959b1c1079c57d46bd41"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/rest","service/ecs"]
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ecs","service/sts"]
   revision = "f9a14dadf426ac17058f5ed3ec9bac9a61b5990b"
   version = "v1.8.33"
 
@@ -23,6 +23,12 @@ memo = "c152d332114f6c773bf013454be5ca197015d70ffb6a454d629fa5a6de61ecf9"
   packages = ["."]
   revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
   version = "0.2.2"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   branch = "master"

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -6,11 +6,11 @@ import (
 )
 
 type deploy struct {
-	cluster string
-	name    string
-	image   string
-	profile string
-	region  string
+	cluster      string
+	name         string
+	imageWithTag string
+	profile      string
+	region       string
 }
 
 func deployCmd() *cobra.Command {
@@ -24,7 +24,7 @@ func deployCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&d.cluster, "cluster", "c", "", "Name of ECS cluster")
 	flags.StringVarP(&d.name, "service-name", "n", "", "Name of service to deploy")
-	flags.StringVarP(&d.image, "image", "i", "", "Name of Docker image to run, ex: repo/image:latest")
+	flags.StringVarP(&d.imageWithTag, "image", "i", "", "Name of Docker image to run, ex: repo/image:latest")
 	flags.StringVarP(&d.profile, "profile", "p", "", "AWS Profile to use")
 	flags.StringVarP(&d.region, "region", "r", "", "AWS Region Name")
 
@@ -32,6 +32,6 @@ func deployCmd() *cobra.Command {
 }
 
 func (d *deploy) deploy(cmd *cobra.Command, args []string) {
-	e := ecsdeploy.NewDeploy(d.cluster, d.name, d.image, d.profile, d.region)
+	e := ecsdeploy.NewDeploy(d.cluster, d.name, d.profile, d.region, d.imageWithTag)
 	e.Deploy()
 }

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -2,9 +2,11 @@ package deploy
 
 import (
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/pkg/errors"
 )
 
 // Deploy have target ecs information
@@ -12,23 +14,48 @@ type Deploy struct {
 	awsECS  *ecs.ECS
 	cluster string
 	name    string
-	image   string
+	image   *string
+	tag     *string
 }
 
 // NewDeploy return a new Deploy struct, and initialize aws ecs api client
-func NewDeploy(cluster, name, image, profile, region string) *Deploy {
+func NewDeploy(cluster, name, profile, region, imageWithTag string) *Deploy {
 	awsECS := ecs.New(session.New(), newConfig(profile, region))
+	var image, tag *string
+	if len(imageWithTag) > 0 {
+		var err error
+		image, tag, err = divideImageAndTag(imageWithTag)
+		if err != nil {
+			log.Fatalf("[ERROR] Can not parse --image parameter: %+v\n", err)
+		}
+	}
 	return &Deploy{
 		awsECS,
 		cluster,
 		name,
 		image,
+		tag,
 	}
 }
 
 // Deploy run deploy commands
 func (d *Deploy) Deploy() {
-	if err := d.TaskDefinition(); err != nil {
-		log.Fatalln(err)
+	task, err := d.TaskDefinition()
+	if err != nil {
+		log.Fatalf("[ERROR] Can not get current task definition: %+v\n", err)
 	}
+	_, err = d.RegisterTaskDefinition(task)
+	if err != nil {
+		log.Fatalf("[ERROR] Can not regist new task definition: %+v\n", err)
+	}
+
+}
+
+func divideImageAndTag(imageWithTag string) (*string, *string, error) {
+	res := strings.Split(imageWithTag, ":")
+	if len(res) >= 3 {
+		return nil, nil, errors.New("image format is wrong.")
+	}
+	return &res[0], &res[1], nil
+
 }

--- a/deploy/task.go
+++ b/deploy/task.go
@@ -1,17 +1,17 @@
 package deploy
 
 import (
-	"log"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+
+	"log"
 )
 
 // TaskDefinition get a current task definition
-func (d *Deploy) TaskDefinition() error {
+func (d *Deploy) TaskDefinition() (*ecs.TaskDefinition, error) {
 	taskArn, err := d.Service()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	params := &ecs.DescribeTaskDefinitionInput{
@@ -19,11 +19,10 @@ func (d *Deploy) TaskDefinition() error {
 	}
 	resp, err := d.awsECS.DescribeTaskDefinition(params)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	log.Println(resp)
-	return nil
+	return resp.TaskDefinition, nil
 }
 
 // Service get target service
@@ -40,4 +39,50 @@ func (d *Deploy) Service() (*string, error) {
 	}
 
 	return resp.Services[0].TaskDefinition, nil
+}
+
+// RegisterTaskDefinition register new task definition if needed
+func (d *Deploy) RegisterTaskDefinition(baseDefinition *ecs.TaskDefinition) (*ecs.TaskDefinition, error) {
+	var containerDefinitions []*ecs.ContainerDefinition
+	for _, c := range baseDefinition.ContainerDefinitions {
+		newDefinition, err := d.NewContainerDefinition(c)
+		if err != nil {
+			return nil, err
+		}
+		containerDefinitions = append(containerDefinitions, newDefinition)
+	}
+	params := &ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions: containerDefinitions,
+		Family:               baseDefinition.Family,
+		NetworkMode:          baseDefinition.NetworkMode,
+		PlacementConstraints: baseDefinition.PlacementConstraints,
+		TaskRoleArn:          baseDefinition.TaskRoleArn,
+		Volumes:              baseDefinition.Volumes,
+	}
+
+	log.Printf("[INFO] new task definition: %+v\n", params)
+	resp, err := d.awsECS.RegisterTaskDefinition(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TaskDefinition, nil
+}
+
+// NewContainerDefinition update image tag in a given container definition.
+// If the container definition is not target container, return givien definition.
+func (d *Deploy) NewContainerDefinition(baseDefinition *ecs.ContainerDefinition) (*ecs.ContainerDefinition, error) {
+	if d.image == nil {
+		return baseDefinition, nil
+	}
+	baseImage, _, err := divideImageAndTag(*baseDefinition.Image)
+	if err != nil {
+		return nil, err
+	}
+	if *d.image != *baseImage {
+		return baseDefinition, nil
+	}
+	imageWithTag := (*d.image) + ":" + (*d.tag)
+	baseDefinition.Image = &imageWithTag
+	return baseDefinition, nil
 }


### PR DESCRIPTION
Before ECS deploy, get current task definition and update image in container definition, then register the task definition.