### PR TITLE
closes #27 Use go-shellwords when parse task commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ecs","service/sts"]
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ecs","service/ecs/ecsiface","service/sts"]
   revision = "f9a14dadf426ac17058f5ed3ec9bac9a61b5990b"
   version = "v1.8.33"
 
@@ -26,6 +26,12 @@
   version = "0.2.2"
 
 [[projects]]
+  name = "github.com/mattn/go-shellwords"
+  packages = ["."]
+  revision = "02e3cf038dcea8290e44424da473dd12be796a8a"
+  version = "v1.0.3"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -46,6 +52,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a7fe1541e2181f4a7d0d25c275e8c161d58dabda1be8959b1c1079c57d46bd41"
+  inputs-digest = "bc3f4297b741642d9c1ebbf781d37eff55c58ad2517eb2eb4463fd9dfecd657f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/deploy/task.go
+++ b/deploy/task.go
@@ -3,13 +3,13 @@ package deploy
 import (
 	"context"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
 )
 
@@ -60,7 +60,11 @@ func NewTask(cluster, name, imageWithTag, command string, baseTaskDefinition *st
 			*tag,
 		}
 	}
-	commands := strings.Split(command, " ")
+	p := shellwords.NewParser()
+	commands, err := p.Parse(command)
+	if err != nil {
+		return nil, errors.Wrap(err, "Parse error in a task command")
+	}
 	var cmd []*string
 	for _, c := range commands {
 		cmd = append(cmd, aws.String(c))


### PR DESCRIPTION
For example, `bash -c "echo $PORT"` will return `["bash", "-c", "echo $PORT"]` using go-shellwords.