### PR TITLE
Update IAM Policy in README because it is insufficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Below is a basic IAM Policy required for ecs-goploy.
       "Sid": "AllowUserToECSDeploy",
       "Effect": "Allow",
       "Action": [
+        "ecr:DescribeRepositories",
+        "ecr:DescribeImages",
         "ecs:DescribeServices",
         "ecs:DescribeTaskDefinition",
         "ecs:RegisterTaskDefinition",


### PR DESCRIPTION
Now ecs-goploy needs `ecr:DescribeRepositories` and `ecr:DescribeImages` to search docker image in ECR. So the IAM policy in README is insufficient.